### PR TITLE
Initial models for ApplicationRecord and Trace

### DIFF
--- a/debugs_bunny.gemspec
+++ b/debugs_bunny.gemspec
@@ -30,9 +30,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'bundle-audit'
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'factory_bot_rails'
+  spec.add_development_dependency 'rails'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-collection_matchers'
@@ -42,4 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'rubocop-rspec'
+  spec.add_development_dependency 'sqlite3'
 end

--- a/debugs_bunny.gemspec
+++ b/debugs_bunny.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'bundle-audit'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/debugs_bunny.rb
+++ b/lib/debugs_bunny.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'debugs_bunny/models/application_record'
+require 'debugs_bunny/models/trace'
 require 'debugs_bunny/version'
 
 module DebugsBunny

--- a/lib/debugs_bunny/models/application_record.rb
+++ b/lib/debugs_bunny/models/application_record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'active_record'
+
+module DebugsBunny
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/lib/debugs_bunny/models/trace.rb
+++ b/lib/debugs_bunny/models/trace.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module DebugsBunny
+  class Trace < DebugsBunny::ApplicationRecord
+    self.abstract_class = true
+  end
+end

--- a/spec/models/debug_trace_spec.rb
+++ b/spec/models/debug_trace_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+class DebugTrace < DebugsBunny::Trace; end
+
+FactoryBot.define do
+  factory :debug_trace, class: 'DebugTrace' do
+    guid { 'dbg_123' } # TODO: remove manual guid when automatic guid creation is implemented
+    dump { 'Mr. Gorbachev, tear down this wall.' }
+  end
+end
+
+RSpec.describe DebugTrace, type: :model do
+  it 'is valid with valid parameters' do
+    debug_trace = build :debug_trace
+    expect(debug_trace).to be_valid
+  end
+
+  it 'is created with a guid' do
+    debug_trace = create :debug_trace
+    expect(debug_trace.guid).to be_present
+  end
+
+  it 'is created with a dump' do
+    debug_trace = create :debug_trace
+    expect(debug_trace.dump).to be_present
+  end
+
+  it 'is created with a timestamp' do
+    debug_trace = create :debug_trace
+    expect(debug_trace.created_at).to be_present
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
+require 'factory_bot'
+
 require 'debugs_bunny'
+require 'support/model_spec_helper'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -10,7 +13,11 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.include FactoryBot::Syntax::Methods
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.include Models, type: :model
 end

--- a/spec/support/model_spec_helper.rb
+++ b/spec/support/model_spec_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Models
+  # Setup temporary database for testing
+  ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
+  load File.dirname(__FILE__) + '/test_schema.rb'
+end

--- a/spec/support/test_schema.rb
+++ b/spec/support/test_schema.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+ActiveRecord::Schema.define do
+  self.verbose = false
+
+  create_table 'debug_traces', force: :cascade do |t|
+    t.string 'guid'
+    t.string 'dump'
+    t.datetime 'created_at'
+  end
+end


### PR DESCRIPTION
Why?

DebugsBunny must provide the ability to create `Traces`; a `Trace` represents a developer-initiated debug trace and stores information relevant to the execution being examined.

How?

Create `ApplicationRecord`, the base class for DebugsBunny's models. `Trace` inherits from `ApplicationRecord`. `Trace` is an abstract model, and must be subclassed by a concrete model in the installing application.

Reviewers

@deankeo 
@gregfletch 
@weiyunlu 