### PR TITLE
Model generator and tests

### DIFF
--- a/lib/generators/debugs_bunny/model/USAGE
+++ b/lib/generators/debugs_bunny/model/USAGE
@@ -1,0 +1,9 @@
+Description:
+    Generates a model for creating debug trace records. The generated model inherits from DebugsBunny::Trace, and
+    includes functionality automatic guid generation and an encrypted data dump field.
+
+Example:
+    rails generate debugs_bunny:model DebugTrace
+
+    This will create:
+        app/models/debug_trace.rb

--- a/lib/generators/debugs_bunny/model/model_generator.rb
+++ b/lib/generators/debugs_bunny/model/model_generator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails/generators'
+
+module DebugsBunny
+  class ModelGenerator < Rails::Generators::NamedBase
+    source_root File.expand_path('templates', __dir__)
+
+    def generate_model
+      models_dir = File.join('app', 'models')
+      model_file = File.join(models_dir, "#{file_name}.rb")
+
+      template 'model_template.erb', model_file
+    end
+  end
+end

--- a/lib/generators/debugs_bunny/model/templates/model_template.erb
+++ b/lib/generators/debugs_bunny/model/templates/model_template.erb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class <%= class_name %> < DebugsBunny::Trace
+  # Add your application logic here
+end

--- a/spec/generators/debugs_bunny/model_generator_spec.rb
+++ b/spec/generators/debugs_bunny/model_generator_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'generators/debugs_bunny/model/model_generator'
+
+RSpec.describe DebugsBunny::ModelGenerator, type: :generator do
+  let(:model_name) { 'DebugTrace' }
+  let(:file_name) { 'debug_trace.rb' }
+
+  before do
+    clone_test_project
+    run_generator model_name
+  end
+
+  after do
+    remove_test_project
+  end
+
+  it 'creates a model file with the given file name' do
+    path = model_file(file_name)
+    expect(File).to exist(path)
+  end
+
+  it 'creates a model with the given model name' do
+    path = model_file(file_name)
+    read_file(path) do |contents|
+      expect(contents).to include "class #{model_name}"
+    end
+  end
+
+  it 'creates a model that inherits from Trace' do
+    path = model_file(file_name)
+    read_file(path) do |contents|
+      expect(contents).to include "class #{model_name} < DebugsBunny::Trace"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,8 @@ if ENV['COVERAGE'] || ENV['CI']
   end
 end
 
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
@@ -37,6 +39,4 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
-
-  config.include Models, type: :model
 end

--- a/spec/support/generator_spec_helper.rb
+++ b/spec/support/generator_spec_helper.rb
@@ -50,14 +50,6 @@ module Generators
   def model_file(file_name)
     File.join(TMP_TEST_PROJECT_MODEL_DIR, file_name)
   end
-
-  def migration_file(file_name)
-    basename = File.basename(file_name)
-    file_path = File.join(TMP_TEST_PROJECT_MIGRATION_DIR, "[0-9]*_#{basename}")
-    file = Dir.glob(file_path).first
-    file = File.join(TMP_TEST_PROJECT_MIGRATION_DIR, "TIMESTAMP_#{basename}") if file.nil?
-    file
-  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/generator_spec_helper.rb
+++ b/spec/support/generator_spec_helper.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Generators
+  extend ActiveSupport::Concern
+
+  ROOT_DIR = File.expand_path('../..', __dir__)
+  SPEC_DIR = File.join(ROOT_DIR, 'spec')
+  TMP_DIR = File.join(ROOT_DIR, 'tmp')
+
+  TEST_PROJECT_NAME = 'rails_test_app'
+
+  SRC_TEST_PROJECT_ROOT_DIR = File.join(SPEC_DIR, TEST_PROJECT_NAME).freeze
+
+  TMP_TEST_PROJECT_ROOT_DIR = File.join(TMP_DIR, TEST_PROJECT_NAME).freeze
+  TMP_TEST_PROJECT_APP_DIR = File.join(TMP_TEST_PROJECT_ROOT_DIR, 'app').freeze
+  TMP_TEST_PROJECT_MODEL_DIR = File.join(TMP_TEST_PROJECT_APP_DIR, 'models').freeze
+  TMP_TEST_PROJECT_MIGRATION_DIR = File.join(TMP_TEST_PROJECT_ROOT_DIR, File.join('db', 'migrate'))
+
+  def generator_class
+    described_class
+  end
+
+  def run_generator(*args, **kw_args)
+    args = Array(args)
+    FileUtils.cd(TMP_TEST_PROJECT_ROOT_DIR) do
+      g = generator_class.new(args, kw_args, {})
+      g.invoke_all
+    end
+  end
+
+  # rubocop:disable Lint/SuppressedException
+  def remove_test_project
+    FileUtils.remove_dir TMP_TEST_PROJECT_ROOT_DIR
+  rescue StandardError
+    # ignored
+  end
+  # rubocop:enable Lint/SuppressedException
+
+  def clone_test_project
+    remove_test_project
+    FileUtils.cp_r SRC_TEST_PROJECT_ROOT_DIR, TMP_DIR
+  end
+
+  def read_file(path)
+    file = File.open(path)
+    contents = file.read
+    yield contents
+    file.close
+  end
+
+  def model_file(file_name)
+    File.join(TMP_TEST_PROJECT_MODEL_DIR, file_name)
+  end
+
+  def migration_file(file_name)
+    basename = File.basename(file_name)
+    file_path = File.join(TMP_TEST_PROJECT_MIGRATION_DIR, "[0-9]*_#{basename}")
+    file = Dir.glob(file_path).first
+    file = File.join(TMP_TEST_PROJECT_MIGRATION_DIR, "TIMESTAMP_#{basename}") if file.nil?
+    file
+  end
+end
+
+RSpec.configure do |config|
+  config.include Generators, type: :generator
+end

--- a/spec/support/generator_spec_helper.rb
+++ b/spec/support/generator_spec_helper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module Generators
-  extend ActiveSupport::Concern
-
   ROOT_DIR = File.expand_path('../..', __dir__)
   SPEC_DIR = File.join(ROOT_DIR, 'spec')
   TMP_DIR = File.join(ROOT_DIR, 'tmp')

--- a/spec/support/generator_spec_helper.rb
+++ b/spec/support/generator_spec_helper.rb
@@ -26,13 +26,9 @@ module Generators
     end
   end
 
-  # rubocop:disable Lint/SuppressedException
   def remove_test_project
-    FileUtils.remove_dir TMP_TEST_PROJECT_ROOT_DIR
-  rescue StandardError
-    # ignored
+    FileUtils.remove_dir TMP_TEST_PROJECT_ROOT_DIR if File.directory?(TMP_TEST_PROJECT_ROOT_DIR)
   end
-  # rubocop:enable Lint/SuppressedException
 
   def clone_test_project
     remove_test_project

--- a/spec/support/generator_spec_helper.rb
+++ b/spec/support/generator_spec_helper.rb
@@ -36,6 +36,7 @@ module Generators
 
   def clone_test_project
     remove_test_project
+    FileUtils.mkdir_p(TMP_DIR) unless File.directory?(TMP_DIR)
     FileUtils.cp_r SRC_TEST_PROJECT_ROOT_DIR, TMP_DIR
   end
 

--- a/spec/support/model_spec_helper.rb
+++ b/spec/support/model_spec_helper.rb
@@ -5,3 +5,7 @@ module Models
   ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
   load File.dirname(__FILE__) + '/test_schema.rb'
 end
+
+RSpec.configure do |config|
+  config.include Models, type: :Model
+end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/8161

*Why?*

Model generator to facilitate the usage of DebugsBunny in installing applications. Developers can invoke this generator to automatically create a model in their application that subclasses DebugsBunny's `Trace`. Note: this model cannot be saved until a corresponding migration is performed. A follow up PR will introduce a migration generator.

This generator can be invoked using `rails generate debugs_bunny:model <ModelName>`. Invoking `rails generate debugs_bunny:model DebugTrace` will generate the following:

```
Running via Spring preloader in process 95256
      create  app/models/debug_trace.rb
```

The resulting model in the application is generated as:
```
# frozen_string_literal: true

class DebugTrace < DebugsBunny::Trace
  # Add your application logic here
end
```

This generator provides a helper description using `rails generate debugs_bunny:model --help` that displays the following:
```
Usage:
  rails generate debugs_bunny:model NAME [options]

Options:
  [--skip-namespace], [--no-skip-namespace]  # Skip namespace (affects only isolated applications)

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Generates a model for creating debug trace records. The generated model inherits from DebugsBunny::Trace, and
    includes functionality automatic guid generation and an encrypted data dump field.

Example:
    rails generate debugs_bunny:model DebugTrace

    This will create:
        app/models/debug_trace.rb
```

*How?*

- New generator in lib/generators for generating the model. The model is generated by instantiating a template ERB `model_template.rb`
- New generator `spec_helper`. Generator tests must copy the test Rails app into the `tmp` and execute tests within this working directory.

*Risks*

None

*Requested Reviewers*

@deankeo 
@gregfletch 
@weiyunlu 