### PR TITLE
Feat: Migration generator

### DIFF
--- a/lib/debugs_bunny/internal/schema/column_descriptor.rb
+++ b/lib/debugs_bunny/internal/schema/column_descriptor.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module DebugsBunny
+  module Internal
+    module Schema
+      class ColumnDescriptor
+        class Option
+          def initialize(key, value)
+            @key = key
+            @value = value
+          end
+
+          def to_s
+            "#{key}: #{value}"
+          end
+
+          private
+
+          attr_reader :key, :value
+        end
+
+        class OptionList
+          delegate_missing_to :options
+
+          def initialize(options)
+            @options = Array(options)
+          end
+
+          def to_s
+            options.map(&:to_s).join(', ')
+          end
+
+          private
+
+          attr_reader :options
+        end
+
+        attr_reader :name, :type, :option_list
+
+        def initialize(name, type, options = {})
+          @name = name
+          @type = type
+          @option_list = OptionList.new(options.map { |key, value| Option.new(key, value) })
+        end
+      end
+    end
+  end
+end

--- a/lib/debugs_bunny/internal/schema/table_descriptor.rb
+++ b/lib/debugs_bunny/internal/schema/table_descriptor.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'column_descriptor'
+
+module DebugsBunny
+  module Internal
+    module Schema
+      class TableDescriptor
+        attr_reader :name
+        attr_reader :column_descriptors
+
+        def initialize(name, *column_descriptors)
+          @name = name
+          @column_descriptors = Array(column_descriptors)
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/debugs_bunny/migration/USAGE
+++ b/lib/generators/debugs_bunny/migration/USAGE
@@ -1,0 +1,10 @@
+Description:
+    Generates a migration for defining a debug trace table. The migration complements the debug trace model. The
+    migration can be performed by invoking rails db:migrate. Once the migration is performed, subclasses of the Trace
+    model can be instantiated and saved to the application's database.
+
+Example:
+    rails generate debugs_bunny:migration debug_traces
+
+    This will create:
+        app/models/debug_traces.rb

--- a/lib/generators/debugs_bunny/migration/USAGE
+++ b/lib/generators/debugs_bunny/migration/USAGE
@@ -4,7 +4,7 @@ Description:
     model can be instantiated and saved to the application's database.
 
 Example:
-    rails generate debugs_bunny:migration debug_traces
+    rails generate debugs_bunny:migration --table_name debug_traces
 
     This will create:
         app/models/debug_traces.rb

--- a/lib/generators/debugs_bunny/migration/migration_generator.rb
+++ b/lib/generators/debugs_bunny/migration/migration_generator.rb
@@ -12,7 +12,7 @@ module DebugsBunny
     source_root File.expand_path('templates', __dir__)
 
     def generate_migration
-      table_name = options['table_name'].to_s.pluralize
+      table_name = options['table_name'].to_s.underscore.pluralize
       table = DebugsBunny::Internal::Schema::TableDescriptor.new(
         table_name,
         DebugsBunny::Internal::Schema::ColumnDescriptor.new(:guid, :string, null: false),

--- a/lib/generators/debugs_bunny/migration/migration_generator.rb
+++ b/lib/generators/debugs_bunny/migration/migration_generator.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails/generators'
+require 'debugs_bunny/internal/schema/table_descriptor'
+
+module DebugsBunny
+  class MigrationGenerator < Rails::Generators::Base
+    include Rails::Generators::Migration
+
+    class_option :table_name, type: :string, required: true
+
+    source_root File.expand_path('templates', __dir__)
+
+    def generate_migration
+      table_name = options['table_name']
+      table = DebugsBunny::Internal::Schema::TableDescriptor.new(
+        table_name,
+        DebugsBunny::Internal::Schema::ColumnDescriptor.new(:guid, :string, null: false),
+        DebugsBunny::Internal::Schema::ColumnDescriptor.new(:dump, :string, null: false)
+      )
+
+      instance_eval do
+        @table = table
+        @active_record_version = ActiveRecord::Migration.current_version
+      end
+
+      migrations_dir = File.join('db', 'migrate')
+      migration_file = File.join(migrations_dir, "create_#{table_name}.rb")
+      migration_template 'migration_template.erb', migration_file
+    end
+
+    def self.next_migration_number(_migration_dir)
+      Time.now.utc.strftime('%Y%m%d%H%M%S')
+    end
+  end
+end

--- a/lib/generators/debugs_bunny/migration/migration_generator.rb
+++ b/lib/generators/debugs_bunny/migration/migration_generator.rb
@@ -12,7 +12,7 @@ module DebugsBunny
     source_root File.expand_path('templates', __dir__)
 
     def generate_migration
-      table_name = options['table_name']
+      table_name = options['table_name'].to_s.pluralize
       table = DebugsBunny::Internal::Schema::TableDescriptor.new(
         table_name,
         DebugsBunny::Internal::Schema::ColumnDescriptor.new(:guid, :string, null: false),

--- a/lib/generators/debugs_bunny/migration/templates/migration_template.erb
+++ b/lib/generators/debugs_bunny/migration/templates/migration_template.erb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class <%= migration_class_name %> < ActiveRecord::Migration[<%= @active_record_version %>]
+  def change
+    create_table :<%= @table.name %>, force: :cascade do |t|
+<%- @table.column_descriptors.each do |column_descriptor| -%>
+      t.<%= column_descriptor.type %> :<%= column_descriptor.name %><%= ", #{column_descriptor.option_list.to_s}" if column_descriptor.option_list.present? %>
+<%- end -%>
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/debugs_bunny/internal/schema/column_descriptor_spec.rb
+++ b/spec/debugs_bunny/internal/schema/column_descriptor_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'debugs_bunny/internal/schema/column_descriptor'
+
+RSpec.describe DebugsBunny::Internal::Schema::ColumnDescriptor do
+  describe described_class::Option do
+    let(:option) { described_class.new(:option, true) }
+
+    describe '#to_s' do
+      it 'returns the Option as a key-value string' do
+        str = option.to_s
+        expect(str).to eq 'option: true'
+      end
+    end
+  end
+
+  describe described_class::OptionList do
+    let(:option_list) do
+      options = [
+        DebugsBunny::Internal::Schema::ColumnDescriptor::Option.new(:colour, :blue),
+        DebugsBunny::Internal::Schema::ColumnDescriptor::Option.new(:size, :medium)
+      ]
+      described_class.new(options)
+    end
+
+    describe '#to_s' do
+      it 'returns the OptionList as a list of key-value strings' do
+        str = option_list.to_s
+        expect(str).to eq 'colour: blue, size: medium'
+      end
+    end
+  end
+
+  describe '#option_list' do
+    let(:column_descriptor) { described_class.new(:text, :string, null: false, default: 'Hello World') }
+
+    it 'returns an OptionList populated by the constructor argument list' do
+      option_list = column_descriptor.option_list
+      expect(option_list.length).to be 2
+      expect(option_list.first.to_s).to eq 'null: false'
+      expect(option_list.second.to_s).to eq 'default: Hello World'
+    end
+  end
+end

--- a/spec/debugs_bunny/internal/schema/column_descriptor_spec.rb
+++ b/spec/debugs_bunny/internal/schema/column_descriptor_spec.rb
@@ -17,18 +17,40 @@ RSpec.describe DebugsBunny::Internal::Schema::ColumnDescriptor do
   end
 
   describe described_class::OptionList do
-    let(:option_list) do
-      options = [
-        DebugsBunny::Internal::Schema::ColumnDescriptor::Option.new(:colour, :blue),
-        DebugsBunny::Internal::Schema::ColumnDescriptor::Option.new(:size, :medium)
-      ]
-      described_class.new(options)
-    end
-
     describe '#to_s' do
+      let(:option_list) do
+        options = [
+          DebugsBunny::Internal::Schema::ColumnDescriptor::Option.new(:colour, :blue),
+          DebugsBunny::Internal::Schema::ColumnDescriptor::Option.new(:size, :medium)
+        ]
+        described_class.new(options)
+      end
+
       it 'returns the OptionList as a list of key-value strings' do
         str = option_list.to_s
         expect(str).to eq 'colour: blue, size: medium'
+      end
+    end
+
+    describe '#blank?' do
+      let(:option_list) { described_class.new([]) }
+
+      it 'returns true if the OptionList contains no Options' do
+        expect(option_list).to be_blank
+      end
+    end
+
+    describe '#present?' do
+      let(:option_list) do
+        options = [
+          DebugsBunny::Internal::Schema::ColumnDescriptor::Option.new(:colour, :blue),
+          DebugsBunny::Internal::Schema::ColumnDescriptor::Option.new(:size, :medium)
+        ]
+        described_class.new(options)
+      end
+
+      it 'returns true if the OptionList contains Options' do
+        expect(option_list).to be_present
       end
     end
   end

--- a/spec/generators/debugs_bunny/migration_generator_spec.rb
+++ b/spec/generators/debugs_bunny/migration_generator_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'generators/debugs_bunny/migration/migration_generator'
+
+RSpec.describe DebugsBunny::MigrationGenerator, type: :generator do
+  let(:table_name) { 'debug_traces' }
+  let(:file_name) { "create_#{table_name}.rb" }
+
+  before do
+    clone_test_project
+    run_generator table_name: table_name
+  end
+
+  after do
+    remove_test_project
+  end
+
+  it 'creates a migration file' do
+    path = migration_file(file_name)
+    expect(File).to exist(path)
+  end
+
+  it 'creates a migration with the given table name' do
+    path = migration_file(file_name)
+    read_file(path) do |contents|
+      expect(contents).to include "create_table :#{table_name}"
+    end
+  end
+
+  it 'creates a migration that inherits from the current ActiveRecord::Migration' do
+    path = migration_file(file_name)
+    read_file(path) do |contents|
+      expect(contents).to include "< ActiveRecord::Migration[#{ActiveRecord::Migration.current_version}]"
+    end
+  end
+
+  it 'creates a migration with the expected guid column' do
+    path = migration_file(file_name)
+    read_file(path) do |contents|
+      expect(contents).to include 't.string :guid, null: false'
+    end
+  end
+
+  it 'creates a migration with the expected dump column' do
+    path = migration_file(file_name)
+    read_file(path) do |contents|
+      expect(contents).to include 't.string :dump, null: false'
+    end
+  end
+
+  it 'creates a migration with the expected timestamp columns' do
+    path = migration_file(file_name)
+    read_file(path) do |contents|
+      expect(contents).to include 't.timestamps'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ require 'factory_bot'
 
 require 'debugs_bunny'
 require 'factories/debug_trace'
-require 'support/model_spec_helper'
 
 if ENV['COVERAGE'] || ENV['CI']
   require 'simplecov'

--- a/spec/support/generator_spec_helper.rb
+++ b/spec/support/generator_spec_helper.rb
@@ -46,6 +46,14 @@ module Generators
   def model_file(file_name)
     File.join(TMP_TEST_PROJECT_MODEL_DIR, file_name)
   end
+
+  def migration_file(file_name)
+    basename = File.basename(file_name)
+    file_path = File.join(TMP_TEST_PROJECT_MIGRATION_DIR, "[0-9]*_#{basename}")
+    file = Dir.glob(file_path).first
+    file = File.join(TMP_TEST_PROJECT_MIGRATION_DIR, "TIMESTAMP_#{basename}") if file.nil?
+    file
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/8161

*Why?*

Follow up PR to add automatic migration generation. This introduces a migration generator to facilitate the usage of DebugsBunny in installing applications. Developers can invoke this generator to automatically create a migration with the required Trace fields in their application so that Trace subclasses can be instantiated and saved to the database.

This generator can be invoked using `rails generate debugs_bunny:migration --table_name <table_name>`. Invoking `rails generate debugs_bunny:migration --table_name debug_trace` will generate the following:

```
Running via Spring preloader in process 49840
      create  db/migrate/20200221233223_create_debug_traces.rb
```

The resulting migration in the application is generated as:
```
# frozen_string_literal: true

class CreateDebugTraces < ActiveRecord::Migration[6.0]
  def change
    create_table :debug_traces, force: :cascade do |t|
      t.string :guid, null: false
      t.string :dump, null: false

      t.timestamps
    end
  end
end
```

This generator provides a helper description using `rails generate debugs_bunny:migration --help` that displays the following:

```
Usage:
  rails generate debugs_bunny:migration [options]

Options:
  [--skip-namespace], [--no-skip-namespace]  # Skip namespace (affects only isolated applications)
  --table-name=TABLE_NAME                    # Indicates when to generate table name

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Generates a migration for defining a debug trace table. The migration complements the debug trace model. The
    migration can be performed by invoking rails db:migrate. Once the migration is performed, subclasses of the Trace
    model can be instantiated and saved to the application's database.

Example:
    rails generate debugs_bunny:migration debug_traces

    This will create:
        app/models/debug_traces.rb
```

*How?*

Added MigrationGenerator and tests. 

*Risks*

None

*Requested Reviewers*

@deankeo 
@gregfletch 
@weiyunlu 
