### PR TITLE
Encrypted dump attribute for trace

### DIFF
--- a/debugs_bunny.gemspec
+++ b/debugs_bunny.gemspec
@@ -47,5 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'sqlite3'
 
+  spec.add_dependency 'attr_encrypted'
+  spec.add_dependency 'daffy_lib'
   spec.add_dependency 'rails'
 end

--- a/lib/debugs_bunny.rb
+++ b/lib/debugs_bunny.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'models/debugs_bunny/concerns/can_generate'
+require 'models/debugs_bunny/concerns/has_encrypted_attributes'
 require 'models/debugs_bunny/concerns/has_guid'
 require 'models/debugs_bunny/application_record'
 require 'models/debugs_bunny/trace'

--- a/lib/debugs_bunny/config.rb
+++ b/lib/debugs_bunny/config.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module DebugsBunny
+  class Config
+    @default_config = {
+      encryption_cmk_key_id: nil,
+      encryption_key_cache_timeout: 5.minutes,
+      encryption_partition_guid: 'DEBUGS_BUNNY_PARTITION'
+    }
+    @allowed_config_keys = @default_config.keys
+
+    class << self
+      attr_reader :default_config, :allowed_config_keys
+    end
+
+    attr_reader :config
+
+    def initialize
+      @config = OpenStruct.new Config.default_config
+    end
+
+    def configure(options)
+      options.each { |key, value| @config.send("#{key.to_sym}=", value) if Config.allowed_config_keys.include? key.to_sym }
+    end
+  end
+
+  mattr_reader :configuration do
+    @config ||= Config.new.config
+  end
+end

--- a/lib/models/debugs_bunny/application_record.rb
+++ b/lib/models/debugs_bunny/application_record.rb
@@ -2,6 +2,8 @@
 
 require 'active_record'
 
+require_relative 'concerns/has_guid'
+
 module DebugsBunny
   class ApplicationRecord < ActiveRecord::Base
     include HasGuid

--- a/lib/models/debugs_bunny/concerns/has_encrypted_attributes.rb
+++ b/lib/models/debugs_bunny/concerns/has_encrypted_attributes.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'active_support/concern'
+
+module DebugsBunny
+  module HasEncryptedAttributes
+    extend ActiveSupport::Concern
+
+    included do
+      require 'attr_encrypted'
+      require 'daffy_lib'
+      include DaffyLib::PartitionProvider
+      include DaffyLib::HasEncryptedAttributes
+    end
+
+    class_methods do
+      def set_encryption_options
+        attr_encrypted_options.merge!(
+          encryptor: DaffyLib::CachingEncryptor,
+          encrypt_method: :zt_encrypt,
+          decrypt_method: :zt_decrypt,
+          partition_guid: proc { |object| object.generate_partition_guid },
+          encryption_epoch: proc { |object| object.generate_encryption_epoch },
+          cmk_key_id: proc { DebugsBunny.configuration.encryption_cmk_key_id },
+          expires_in: proc { DebugsBunny.configuration.encryption_key_cache_timeout }
+        )
+      end
+
+      def define_encrypted_attributes
+        define_singleton_method(:set_encrypted_attributes) do
+          set_encryption_options
+          yield
+        end
+        set_encrypted_attributes
+      end
+    end
+  end
+end

--- a/lib/models/debugs_bunny/encryption_key.rb
+++ b/lib/models/debugs_bunny/encryption_key.rb
@@ -2,6 +2,8 @@
 
 require 'daffy_lib'
 
+require_relative 'concerns/can_generate'
+
 module DebugsBunny
   class EncryptionKey < ::DaffyLib::EncryptionKey
     include CanGenerate

--- a/lib/models/debugs_bunny/encryption_key.rb
+++ b/lib/models/debugs_bunny/encryption_key.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'daffy_lib'
+
+module DebugsBunny
+  class EncryptionKey < ::DaffyLib::EncryptionKey
+    include CanGenerate
+
+    table_descriptor.name = 'encryption_keys'
+
+    define_table do |t|
+      t.define_column :encrypted_data_encryption_key, :string, null: false
+      t.define_column :guid, :string, null: false
+      t.define_column :key_epoch, :datetime, null: false
+      t.define_column :partition_guid, :string, null: false
+      t.define_column :version, :string, null: false
+      t.define_index :index_encryption_keys_on_guid, %w[guid], unique: true
+      t.define_index :index_encryption_keys, %w[partition_guid key_epoch], unique: true
+    end
+  end
+end

--- a/lib/models/debugs_bunny/trace.rb
+++ b/lib/models/debugs_bunny/trace.rb
@@ -1,19 +1,31 @@
 # frozen_string_literal: true
 
-require_relative 'concerns/can_generate'
+require 'debugs_bunny/config'
+require 'debugs_bunny/internal/schema/column_descriptor'
 
 module DebugsBunny
   class Trace < DebugsBunny::ApplicationRecord
     include CanGenerate
+    include HasEncryptedAttributes
 
     self.abstract_class = true
 
     has_guid 'trc'
 
+    def generate_partition_guid
+      self.partition_guid = DebugsBunny.configuration.encryption_partition_guid
+    end
+
+    define_encrypted_attributes do
+      attr_encrypted :dump
+    end
+
     define_table do |t|
       t.define_column :guid, :string, null: false
-      t.define_column :dump, :string, null: false
-      t.define_index :unique_guid, [:guid], unique: true
+      t.define_column :encrypted_dump, :string
+      t.define_column :encrypted_dump_iv, :string
+      t.define_column :partition_guid, :string, null: false
+      t.define_column :encryption_epoch, :string, datetime: false
     end
   end
 end

--- a/lib/models/debugs_bunny/trace.rb
+++ b/lib/models/debugs_bunny/trace.rb
@@ -25,7 +25,7 @@ module DebugsBunny
       t.define_column :encrypted_dump, :string
       t.define_column :encrypted_dump_iv, :string
       t.define_column :partition_guid, :string, null: false
-      t.define_column :encryption_epoch, :string, datetime: false
+      t.define_column :encryption_epoch, :string, null: false
     end
   end
 end

--- a/lib/models/debugs_bunny/trace.rb
+++ b/lib/models/debugs_bunny/trace.rb
@@ -26,6 +26,7 @@ module DebugsBunny
       t.define_column :encrypted_dump_iv, :string
       t.define_column :partition_guid, :string, null: false
       t.define_column :encryption_epoch, :string, null: false
+      t.define_index :unique_guid, [:guid], unique: true
     end
   end
 end

--- a/lib/models/debugs_bunny/trace.rb
+++ b/lib/models/debugs_bunny/trace.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'application_record'
 require_relative 'concerns/can_generate'
-require_relative 'concerns/concerns/has_encrypted_attributes'
+require_relative 'concerns/has_encrypted_attributes'
 require 'debugs_bunny/config'
 require 'debugs_bunny/internal/schema/column_descriptor'
 

--- a/lib/models/debugs_bunny/trace.rb
+++ b/lib/models/debugs_bunny/trace.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'concerns/can_generate'
+require_relative 'concerns/concerns/has_encrypted_attributes'
 require 'debugs_bunny/config'
 require 'debugs_bunny/internal/schema/column_descriptor'
 

--- a/spec/generators/debugs_bunny/migration/create_traces_generator_spec.rb
+++ b/spec/generators/debugs_bunny/migration/create_traces_generator_spec.rb
@@ -43,10 +43,11 @@ RSpec.describe DebugsBunny::Migration::CreateTracesGenerator, type: :generator d
     end
   end
 
-  it 'creates a migration with the expected dump column' do
+  it 'creates a migration with the expected encrypted dump columns' do
     path = migration_file(file_name)
     read_file(path) do |contents|
-      expect(contents).to include 't.string :dump, null: false'
+      expect(contents).to include 't.string :encrypted_dump'
+      expect(contents).to include 't.string :encrypted_dump_iv'
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 require 'bundler/setup'
 require 'factory_bot'
+require 'rails/all'
+require 'porky_lib'
 
 require 'debugs_bunny'
 require 'factories/debug_trace'
@@ -37,5 +39,22 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  PorkyLib::Config.configure(aws_region: 'us-east-1',
+                             aws_key_id: 'key_id',
+                             aws_key_secret: 'key_secret',
+                             aws_client_mock: true)
+  PorkyLib::Config.initialize_aws
+
+  DebugsBunny.configuration.encryption_cmk_key_id = 'test_cmk_id'
+
+  RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+  config.before do
+    logger = Logger.new($stdout)
+    allow(Rails).to receive(:logger).and_return(logger)
+    allow(Rails.cache).to receive(:write)
+    allow(Rails.cache).to receive(:read)
   end
 end

--- a/spec/support/test_schema.rb
+++ b/spec/support/test_schema.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'models/debugs_bunny/trace'
+require 'models/debugs_bunny/encryption_key'
 
 ActiveRecord::Schema.define do
   self.verbose = false
@@ -11,6 +12,16 @@ ActiveRecord::Schema.define do
     end
     t.timestamps
     DebugsBunny::Trace.table_descriptor.index_descriptors.each do |index|
+      t.send(:index, index.columns, index.option_list.to_h)
+    end
+  end
+
+  create_table 'encryption_keys', force: :cascade do |t|
+    DebugsBunny::EncryptionKey.table_descriptor.column_descriptors.each do |column|
+      t.send(column.type, column.name, column.option_list.to_h)
+    end
+    t.timestamps
+    DebugsBunny::EncryptionKey.table_descriptor.index_descriptors.each do |index|
       t.send(:index, index.columns, index.option_list.to_h)
     end
   end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/8161

*Why?*

Because Traces can contain sensitive data, like PII, the trace dump must be encrypted. This PR uses DaffyLib and PorkyLib to perform encryption.

*How?*

- Use `attr_encrypted` to define encrypted model attributes
- Use `DaffyLib::CachingEncryptor` to perform encryption
- Updated `Trace` table to store encryption fields, i.e. `encrypted_dump`, `encrypted_dump_iv`, `partition_guid`, and `encryption_epoch`

*Risks*

- Encryption failures related to AWS service outages, communication failures, etc.

*Requested Reviewers*

@deankeo 
@gregfletch 
@weiyunlu 
