### PR TITLE
Feat: CreateEncryptionKeysGenerator

### DIFF
--- a/lib/generators/debugs_bunny/migration/create_encryption_keys/create_encryption_keys_generator.rb
+++ b/lib/generators/debugs_bunny/migration/create_encryption_keys/create_encryption_keys_generator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'active_record'
+require 'rails/generators'
+require 'models/debugs_bunny/encryption_key'
+
+module DebugsBunny
+  module Migration
+    class CreateEncryptionKeysGenerator < Rails::Generators::Base
+      include Rails::Generators::Migration
+
+      TEMPLATE_DIR = File.join(TEMPLATES_DIR, 'migrations')
+      source_root TEMPLATE_DIR
+
+      def generate_migration
+        table = DebugsBunny::EncryptionKey.table_descriptor
+
+        if ActiveRecord::Base.connection.table_exists?(table.name)
+          puts "#{self.class.name}: The table #{table.name} already exists. A new migration will not be generated."
+          return
+        end
+
+        instance_eval do
+          @table = table
+          @active_record_version = ActiveRecord::Migration.current_version
+        end
+
+        migrations_dir = File.join('db', 'migrate')
+        migration_file = File.join(migrations_dir, "create_#{table.name}.rb")
+        migration_template 'create_table.erb', migration_file
+      end
+
+      def self.next_migration_number(_migration_dir)
+        Time.now.utc.strftime('%Y%m%d%H%M%S')
+      end
+    end
+  end
+end

--- a/spec/generators/debugs_bunny/migration/create_encryption_keys_generator_spec.rb
+++ b/spec/generators/debugs_bunny/migration/create_encryption_keys_generator_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'generators/debugs_bunny/migration/create_encryption_keys/create_encryption_keys_generator'
+
+RSpec.describe DebugsBunny::Migration::CreateEncryptionKeysGenerator, type: :generator do
+  let(:table_name) { 'encryption_keys' }
+  let(:file_name) { "create_#{table_name}.rb" }
+
+  before do
+    clone_test_project
+    allow(ActiveRecord::Base.connection).to receive(:table_exists?).and_return(false)
+  end
+
+  after do
+    remove_test_project
+  end
+
+  it 'creates a migration file' do
+    run_generator table_name: table_name
+    path = migration_file(file_name)
+    expect(File).to exist(path)
+  end
+
+  it 'does not create a migration file if the table already exists' do
+    allow(ActiveRecord::Base.connection).to receive(:table_exists?).and_return(true)
+    run_generator table_name: table_name
+    path = migration_file(file_name)
+    expect(File).not_to exist(path)
+  end
+
+  it 'creates a migration with the given table name' do
+    run_generator table_name: table_name
+    path = migration_file(file_name)
+    read_file(path) do |contents|
+      expect(contents).to include "create_table :#{table_name}"
+    end
+  end
+
+  it 'creates a migration that inherits from the current ActiveRecord::Migration' do
+    run_generator table_name: table_name
+    path = migration_file(file_name)
+    read_file(path) do |contents|
+      expect(contents).to include "< ActiveRecord::Migration[#{ActiveRecord::Migration.current_version}]"
+    end
+  end
+
+  it 'creates a migration with the expected guid column' do
+    run_generator table_name: table_name
+    path = migration_file(file_name)
+    read_file(path) do |contents|
+      expect(contents).to include 't.string :guid, null: false'
+    end
+  end
+
+  it 'creates a migration with the expected timestamp columns' do
+    run_generator table_name: table_name
+    path = migration_file(file_name)
+    read_file(path) do |contents|
+      expect(contents).to include 't.timestamps'
+    end
+  end
+end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/8161

*Why?*

DebugsBunny delegates encryption functionality to DaffyLib, where data encryption keys are stored in the database. Client applications installing DebugsBunny will need a corresponding encryption key table. Because the schema of this table is deterministic and defined by DaffyLib, DebugsBunny can automatically generate this encryption key table at installation time. This simplifies the installation process for clients using DebugsBunny and hides implementation details.

*How?*

- Created new `CreateEncryptionKeysGenerator`
- CreateEncryptionKeysGenerator only generates a new migration when the client does not already have an `encryption_keys` table
- Tests

*Risks*

None

*Requested Reviewers*

@deankeo 
@gregfletch 
@weiyunlu 