### PR TITLE
Feat: Handle Errors generated by HasEncryptedAttributes

### DIFF
--- a/lib/models/debugs_bunny/concerns/has_encrypted_attributes.rb
+++ b/lib/models/debugs_bunny/concerns/has_encrypted_attributes.rb
@@ -1,22 +1,93 @@
 # frozen_string_literal: true
 
 require 'active_support/concern'
+require 'daffy_lib'
 
 module DebugsBunny
   module HasEncryptedAttributes
     extend ActiveSupport::Concern
 
+    module InstantiationErrors
+      extend ActiveSupport::Concern
+
+      DAFFY_LIB_HANDLED_ERRORS = [
+        ::DaffyLib::CachingEncryptor::EncryptionFailedException,
+        ::DaffyLib::CachingEncryptor::InvalidParameterException
+      ].freeze
+
+      class_methods do
+        def new(*args, &block)
+          if args.first&.delete(:skip_handle_errors)
+            super
+          else
+            handle_instantiation_errors { super }
+          end
+        end
+
+        def create(*args)
+          # Signal that errors should be not be handled within new
+          args.first&.merge!(skip_handle_errors: true)
+          handle_instantiation_errors { super }
+        end
+
+        def create!(*args)
+          # Signal that errors should be not be handled within new
+          args.first&.merge!(skip_handle_errors: true)
+          handle_instantiation_errors { super }
+        end
+
+        def handle_instantiation_errors
+          yield
+        rescue *DAFFY_LIB_HANDLED_ERRORS => e
+          message = "DebugsBunny failed to instantiate a new #{name} record:\n"\
+                    "#{e.message}\n"\
+                    'Have you configured DebugsBunny and PorkyLib?'
+          Rails.logger.error(message)
+        rescue StandardError => e
+          message = "DebugsBunny failed to instantiate a new #{name} record due to an unknown error:\n"\
+                    "#{e.message}"
+          Rails.logger.error(message)
+        end
+      end
+    end
+
+    module DecryptionErrors
+      extend ActiveSupport::Concern
+
+      DAFFY_LIB_HANDLED_ERRORS = [
+        ::DaffyLib::CachingEncryptor::DecryptionFailedException,
+        ::DaffyLib::CachingEncryptor::InvalidParameterException
+      ].freeze
+
+      def decrypt(attribute, *args)
+        handle_decryption_errors(attribute) { super }
+      end
+
+      def handle_decryption_errors(attribute)
+        yield
+      rescue *DAFFY_LIB_HANDLED_ERRORS => e
+        message = "DebugsBunny failed to decrypt #{attribute}:\n"\
+                  "#{e.message}\n"
+        Rails.logger.error(message)
+      rescue StandardError => e
+        message = "DebugsBunny failed to decrypt #{attribute} due to an unknown error:\n"\
+                  "#{e.message}"
+        Rails.logger.error(message)
+      end
+    end
+
     included do
       require 'attr_encrypted'
-      require 'daffy_lib'
-      include DaffyLib::PartitionProvider
-      include DaffyLib::HasEncryptedAttributes
+      include ::DaffyLib::PartitionProvider
+      include ::DaffyLib::HasEncryptedAttributes
+      include InstantiationErrors
+      include DecryptionErrors
     end
 
     class_methods do
       def set_encryption_options
         attr_encrypted_options.merge!(
-          encryptor: DaffyLib::CachingEncryptor,
+          encryptor: ::DaffyLib::CachingEncryptor,
           encrypt_method: :zt_encrypt,
           decrypt_method: :zt_decrypt,
           partition_guid: proc { |object| object.generate_partition_guid },

--- a/spec/models/debugs_bunny/debug_trace_spec.rb
+++ b/spec/models/debugs_bunny/debug_trace_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe DebugTrace, type: :model do
     expect(debug_trace).to be_valid
   end
 
+  it 'is valid without a dump' do
+    debug_trace = build :debug_trace, dump: nil
+    expect(debug_trace).to be_valid
+  end
+
   it 'is created with a guid' do
     debug_trace = create :debug_trace
     expect(debug_trace.guid).to be_present
@@ -18,6 +23,12 @@ RSpec.describe DebugTrace, type: :model do
   it 'is created with a dump' do
     debug_trace = create :debug_trace
     expect(debug_trace.dump).to be_present
+  end
+
+  it 'is loaded with the created dump' do
+    debug_trace = create :debug_trace, dump: 'test'
+    db_debug_trace = described_class.find(debug_trace.id)
+    expect(db_debug_trace.dump).to eq 'test'
   end
 
   it 'is created with a timestamp' do

--- a/spec/models/debugs_bunny/has_encrypted_attributes_spec.rb
+++ b/spec/models/debugs_bunny/has_encrypted_attributes_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'models/debugs_bunny/concerns/has_encrypted_attributes'
+
+class DebugTrace < DebugsBunny::Trace; end
+
+RSpec.describe DebugsBunny::HasEncryptedAttributes do
+  subject { DebugTrace }
+
+  before do
+    allow(Rails.logger).to receive(:error).and_call_original
+  end
+
+  shared_examples 'instantiation' do |instantiation_method|
+    let(:instantiation_error_message) { /DebugsBunny failed to instantiate a new #{subject.name} record:/ }
+    let(:instantiation_unknown_error_message) { /DebugsBunny failed to instantiate a new #{subject.name} record due to an unknown error:/ }
+
+    it "logs an error message on #{instantiation_method} when DaffyLib raises EncryptionFailedException" do
+      allow(DaffyLib::CachingEncryptor).to receive(:zt_encrypt).and_raise(DaffyLib::CachingEncryptor::EncryptionFailedException)
+      expect { subject.send(instantiation_method, dump: 'test') }.not_to raise_error
+      expect(Rails.logger).to have_received(:error).with(instantiation_error_message).once
+      expect(Rails.logger).not_to have_received(:error).with(instantiation_unknown_error_message)
+    end
+
+    it "logs an error message on #{instantiation_method} when DaffyLib raises InvalidParameterException" do
+      allow(DaffyLib::CachingEncryptor).to receive(:zt_encrypt).and_raise(DaffyLib::CachingEncryptor::InvalidParameterException)
+      expect { subject.send(instantiation_method, dump: 'test') }.not_to raise_error
+      expect(Rails.logger).to have_received(:error).with(instantiation_error_message).once
+      expect(Rails.logger).not_to have_received(:error).with(instantiation_unknown_error_message)
+    end
+
+    it "logs an error message on #{instantiation_method} when any other exception is raised" do
+      allow(DaffyLib::CachingEncryptor).to receive(:zt_encrypt).and_raise(StandardError, 'Something bad happened...')
+      expect { subject.send(instantiation_method, dump: 'test') }.not_to raise_error
+      expect(Rails.logger).not_to have_received(:error).with(instantiation_error_message)
+      expect(Rails.logger).to have_received(:error).with(instantiation_unknown_error_message).once
+    end
+  end
+
+  shared_examples 'decrypt' do
+    let(:decrypt_error_message) { /DebugsBunny failed to decrypt dump:/ }
+    let(:decrypt_unknown_error_message) { /DebugsBunny failed to decrypt dump due to an unknown error:/ }
+    let(:instance) { create :debug_trace }
+    let(:db_instance) { subject.find(instance.id) }
+
+    it 'logs an error message on encrypted attribute read when DaffyLib raises DecryptionFailedException' do
+      allow(DaffyLib::CachingEncryptor).to receive(:zt_decrypt).and_raise(DaffyLib::CachingEncryptor::DecryptionFailedException)
+      expect { db_instance.dump }.not_to raise_error
+      expect(Rails.logger).to have_received(:error).with(decrypt_error_message).once
+      expect(Rails.logger).not_to have_received(:error).with(decrypt_unknown_error_message)
+    end
+
+    it 'logs an error message on encrypted attribute read when DaffyLib raises InvalidParameterException' do
+      allow(DaffyLib::CachingEncryptor).to receive(:zt_decrypt).and_raise(DaffyLib::CachingEncryptor::InvalidParameterException)
+      expect { db_instance.dump }.not_to raise_error
+      expect(Rails.logger).to have_received(:error).with(decrypt_error_message).once
+      expect(Rails.logger).not_to have_received(:error).with(decrypt_unknown_error_message)
+    end
+
+    it 'logs an error message on encrypted attribute read when any other exception is raised' do
+      allow(DaffyLib::CachingEncryptor).to receive(:zt_decrypt).and_raise(StandardError)
+      expect { db_instance.dump }.not_to raise_error
+      expect(Rails.logger).not_to have_received(:error).with(decrypt_error_message)
+      expect(Rails.logger).to have_received(:error).with(decrypt_unknown_error_message).once
+    end
+  end
+
+  include_examples 'instantiation', :new
+  include_examples 'instantiation', :create
+  include_examples 'instantiation', :create!
+  include_examples 'decrypt'
+end

--- a/spec/models/debugs_bunny/has_guid_spec.rb
+++ b/spec/models/debugs_bunny/has_guid_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
 require 'models/debugs_bunny/concerns/has_guid'
 
 class DebugTrace < DebugsBunny::Trace; end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/8161

*Why?*

Because DebugsBunny is strictly for debugging and not for functional use, creating instances of DebugsBunny `Traces` and related encryption/decryption functions should never raise an error to the client application. Failures should be handled as to not interrupt functional codepaths.  

This PR adds error handling to records with encrypted attributes on creation and read. Respectively, these operations map to encryption and decryption, both of which are liable to fail. The error handling captures all errors and prevents them from propagating back to the client.

*How?*

Added submodules to the `HasEncryptedAttributes` module:
- `InstantiationErrors`
- `DecryptionErrors`

These submodules handle errors created by their respective operations.

*Risks*

Some errors related to AWS client configuration and TCP connections may still fail and propagate back to the client. Ideally, these errors can be handled by PorkyLib and DaffyLib, such that DebugsBunny can handle their errors specifically.

*Requested Reviewers*

@deankeo 
@gregfletch 
@weiyunlu 