### PR TITLE
Initializer generator

### DIFF
--- a/lib/debugs_bunny/internal/templates/initializers/debugs_bunny.erb
+++ b/lib/debugs_bunny/internal/templates/initializers/debugs_bunny.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'debugs_bunny'
+
+DebugsBunny.configuration.encryption_cmk_key_id = DEBUGS_BUNNY_ALIAS # Change me to your CMK Key ID
+DebugsBunny.configuration.encryption_key_cache_timeout = 5.minutes
+DebugsBunny.configuration.encryption_partition_guid = 'DEBUGS_BUNNY_PARTITION'

--- a/lib/generators/debugs_bunny/config/USAGE
+++ b/lib/generators/debugs_bunny/config/USAGE
@@ -1,0 +1,10 @@
+Description:
+    Generates an initializer wherein the client application can configure their DebugsBunny installation. At a minimum,
+    the client must define a CMK key ID by assigning a value to DebugsBunny.configuration.encryption_cmk_key_id.
+    Additionally, the client can override the default values for the key cache timeout and partition GUID.
+
+Example:
+    rails generate debugs_bunny:config
+
+    This will create:
+        config/initializers/debugs_bunny.rb

--- a/lib/generators/debugs_bunny/config/config_generator.rb
+++ b/lib/generators/debugs_bunny/config/config_generator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'active_record'
+require 'rails/generators'
+
+module DebugsBunny
+  class ConfigGenerator < Rails::Generators::Base
+    TEMPLATE_DIR = File.join(TEMPLATES_DIR, 'initializers')
+    source_root TEMPLATE_DIR
+
+    def generate_initializer
+      initializers_dir = File.join('config', 'initializers')
+      initializer_file = File.join(initializers_dir, 'debugs_bunny.rb')
+      template 'debugs_bunny.erb', initializer_file
+    end
+  end
+end

--- a/spec/generators/debugs_bunny/config_generator_spec.rb
+++ b/spec/generators/debugs_bunny/config_generator_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'generators/debugs_bunny/initializer/config/config_generator'
+
+RSpec.describe DebugsBunny::ConfigGenerator, type: :generator do
+  before do
+    clone_test_project
+    run_generator
+  end
+
+  after do
+    remove_test_project
+  end
+
+  it 'creates an initializer file with the expected file name' do
+    path = initializer_file('debugs_bunny.rb')
+    expect(File).to exist(path)
+  end
+end

--- a/spec/generators/debugs_bunny/config_generator_spec.rb
+++ b/spec/generators/debugs_bunny/config_generator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-require 'generators/debugs_bunny/initializer/config/config_generator'
+require 'generators/debugs_bunny/config/config_generator'
 
 RSpec.describe DebugsBunny::ConfigGenerator, type: :generator do
   before do

--- a/spec/support/generator_spec_helper.rb
+++ b/spec/support/generator_spec_helper.rb
@@ -13,6 +13,8 @@ module Generators
   TMP_TEST_PROJECT_APP_DIR = File.join(TMP_TEST_PROJECT_ROOT_DIR, 'app').freeze
   TMP_TEST_PROJECT_MODEL_DIR = File.join(TMP_TEST_PROJECT_APP_DIR, 'models').freeze
   TMP_TEST_PROJECT_MIGRATION_DIR = File.join(TMP_TEST_PROJECT_ROOT_DIR, File.join('db', 'migrate'))
+  TMP_TEST_PROJECT_CONFIG_DIR = File.join(TMP_TEST_PROJECT_ROOT_DIR, 'config').freeze
+  TMP_TEST_PROJECT_INITIALIZERS_DIR = File.join(TMP_TEST_PROJECT_CONFIG_DIR, 'initializers').freeze
 
   def generator_class
     described_class
@@ -41,6 +43,10 @@ module Generators
     contents = file.read
     yield contents
     file.close
+  end
+
+  def initializer_file(file_name)
+    File.join(TMP_TEST_PROJECT_INITIALIZERS_DIR, file_name)
   end
 
   def model_file(file_name)


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/8161

*Why?*

When using DebugsBunny, the client application must configure their DebugsBunny settings to define a mandatory CMK key ID, and optionally override default values for the data key cache time and partition guid.

*How?*

The best way for a client application to define their DebugsBunny settings is in a Rails initializer. This allows the application to define these settings deterministically and prior to use. This PR introduces a generator to install a skeleton initializer that users can use to quickly and easily define these settings. 

*Risks*

None

*Requested Reviewers*

@deankeo 
@gregfletch 
@weiyunlu 