### PR TITLE
Feat: Install generator

### DIFF
--- a/lib/generators/debugs_bunny/install/USAGE
+++ b/lib/generators/debugs_bunny/install/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Generates the files needed by the client application to use and configure BugsBunny. This command invokes a
+    Generates the files needed by the client application to use and configure DebugsBunny. This command invokes a
 
 Example:
     rails generate debugs_bunny:install

--- a/lib/generators/debugs_bunny/install/USAGE
+++ b/lib/generators/debugs_bunny/install/USAGE
@@ -1,5 +1,6 @@
 Description:
-    Generates the files needed by the client application to use and configure DebugsBunny. This command invokes a
+    Generates the files needed by the client application to use and configure DebugsBunny. This command invokes other
+    generators necessary for installation.
 
 Example:
     rails generate debugs_bunny:install

--- a/lib/generators/debugs_bunny/install/USAGE
+++ b/lib/generators/debugs_bunny/install/USAGE
@@ -1,0 +1,11 @@
+Description:
+    Generates the files needed by the client application to use and configure BugsBunny. This command invokes a
+
+Example:
+    rails generate debugs_bunny:install
+
+    This will create:
+        app/migrate/<timestamp>_create_debug_traces
+        app/migrate/<timestamp>_create_encryption_keys
+        app/models/debug_traces.rb
+        config/initializers/debugs_bunny.rb

--- a/lib/generators/debugs_bunny/install/install_generator.rb
+++ b/lib/generators/debugs_bunny/install/install_generator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails/generators'
+
+module DebugsBunny
+  class InstallGenerator < Rails::Generators::Base
+    def install
+      model_name = 'DebugTrace'
+      generate "debugs_bunny:trace #{model_name}"
+      generate "debugs_bunny:migration:create_traces --table_name #{model_name}"
+      generate 'debugs_bunny:migration:create_encryption_keys'
+      generate 'debugs_bunny:config'
+    end
+  end
+end

--- a/lib/generators/debugs_bunny/migration/create_encryption_keys/USAGE
+++ b/lib/generators/debugs_bunny/migration/create_encryption_keys/USAGE
@@ -1,10 +1,9 @@
 Description:
-    Generates a migration for defining a debug trace table. The migration complements the debug trace model. The
-    migration can be performed by invoking rails db:migrate. Once the migration is performed, subclasses of the Trace
-    model can be instantiated and saved to the application's database.
+    Generates a migration for creating the encryption keys table used by DaffyLib. If this table already exists, this
+    generator does not create a new migration.
 
 Example:
-    rails generate debugs_bunny:migration --table_name debug_traces
+    rails generate debugs_bunny:migration:create_encryption_keys
 
     This will create:
-        app/models/debug_traces.rb
+        db/migrate/<timestamp>_create_encryption_keys.rb

--- a/lib/generators/debugs_bunny/migration/create_traces/USAGE
+++ b/lib/generators/debugs_bunny/migration/create_traces/USAGE
@@ -7,4 +7,4 @@ Example:
     rails generate debugs_bunny:migration:create_traces --table_name debug_traces
 
     This will create:
-        app/models/debug_traces.rb
+        db/migrate/<timestamp>_create_debug_traces.rb

--- a/spec/generators/debugs_bunny/install_generator_spec.rb
+++ b/spec/generators/debugs_bunny/install_generator_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'generators/debugs_bunny/install/install_generator'
+
+RSpec.describe DebugsBunny::InstallGenerator, type: :generator do
+  let(:debug_trace_model_name) { 'DebugTrace' }
+  let(:debug_trace_model_file_name) { "#{debug_trace_model_name.underscore}.rb" }
+  let(:debug_trace_migration_file_name) { "create_#{debug_trace_model_name.underscore.pluralize}.rb" }
+  let(:encryption_key_migration_file_name) { 'create_encryption_keys.rb' }
+
+  before do
+    clone_test_project
+    run_generator
+  end
+
+  after do
+    remove_test_project
+  end
+
+  it 'creates the DebugTrace model file' do
+    path = model_file(debug_trace_model_file_name)
+    expect(File).to exist(path)
+  end
+
+  it 'creates the DebugTrace migration file' do
+    path = migration_file(debug_trace_migration_file_name)
+    expect(File).to exist(path)
+  end
+
+  it 'creates the EncryptionKey migration file' do
+    path = migration_file(encryption_key_migration_file_name)
+    expect(File).to exist(path)
+  end
+
+  it 'creates the configuration initializer file' do
+    path = initializer_file('debugs_bunny.rb')
+    expect(File).to exist(path)
+  end
+end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/8161

*Why?*

Using DebugsBunny requires a number of prerequisite steps and configurations. These steps are largely the same for every application; therefore, we can automate the installation process. This generator automates the install steps so client applications can use DebugsBunny with little human intervention.  

*How?*

Users can install DebugsBunny by invoking this generator with `rails g debugs_bunny:install`

*Risks*

None

*Requested Reviewers*

@deankeo 
@gregfletch 
@weiyunlu 
