### PR TITLE
Feat: Add Rake task to delete expire traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,44 @@ Or install it yourself as:
 
     $ gem install debugs_bunny
 
+Once it is installed, you can automatically generate relevant files using:
+
+    $ rails generate debugs_bunny:install
+
 ## Usage
 
-TODO: Write usage instructions here
+Once installed, Traces can be created in the following manner: 
+
+```ruby
+dump = {}
+dump[:authentication] = request&.authentication
+dump[:args] = context[:args]
+dump[:cassette_name] = context[:cassette_name]
+dump[:endpoint] = endpoint.class.name
+dump[:error] = response&.error&.name
+dump[:error_message] = response&.error_message
+dump[:headers] = request&.headers
+dump[:http_code] = response&.http_code
+dump[:http_method] = endpoint.class.http_method
+dump[:outgoing_request_id] = request&.id
+dump[:payload] = request&.payload
+dump[:response] = response&.body
+dump[:retries] = context[:retries] || 0
+dump[:url] = endpoint.url
+
+json = dump.to_json
+trace = DebugTrace.create(dump: json)
+```
+
+DebugsBunny provides a Rake task to automatically clear Traces older than the configured lifetime:
+
+    $ rake debugs_bunny:delete_expired_traces
+    
+The Trace lifetime can be configured by the application. By default, this is set in the generated `debugs_bunny.rb` initializer:
+
+```ruby
+DebugsBunny.configuration.max_age = 1.week
+```
 
 ## Development
 

--- a/debugs_bunny.gemspec
+++ b/debugs_bunny.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundle-audit'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'codecov'
+  spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'factory_bot_rails'
   spec.add_development_dependency 'rails'
   spec.add_development_dependency 'rake'

--- a/lib/debugs_bunny.rb
+++ b/lib/debugs_bunny.rb
@@ -7,6 +7,8 @@ require 'models/debugs_bunny/application_record'
 require 'models/debugs_bunny/trace'
 require 'debugs_bunny/version'
 
+require 'debugs_bunny/railtie' if defined?(Rails)
+
 module DebugsBunny
   LIB_DIR = File.expand_path('./debugs_bunny', __dir__)
   INTERNAL_DIR = File.join(LIB_DIR, 'internal')

--- a/lib/debugs_bunny.rb
+++ b/lib/debugs_bunny.rb
@@ -13,4 +13,5 @@ module DebugsBunny
   LIB_DIR = File.expand_path('./debugs_bunny', __dir__)
   INTERNAL_DIR = File.join(LIB_DIR, 'internal')
   TEMPLATES_DIR = File.join(INTERNAL_DIR, 'templates')
+  TASKS_DIR = File.join(LIB_DIR, 'tasks')
 end

--- a/lib/debugs_bunny/config.rb
+++ b/lib/debugs_bunny/config.rb
@@ -5,7 +5,8 @@ module DebugsBunny
     @default_config = {
       encryption_cmk_key_id: nil,
       encryption_key_cache_timeout: 5.minutes,
-      encryption_partition_guid: 'DEBUGS_BUNNY_PARTITION'
+      encryption_partition_guid: 'DEBUGS_BUNNY_PARTITION',
+      max_age: 1.week
     }
     @allowed_config_keys = @default_config.keys
 
@@ -26,5 +27,9 @@ module DebugsBunny
 
   mattr_reader :configuration do
     @config ||= Config.new.config
+  end
+
+  mattr_reader :default_configuration do
+    @default_configuration || Config.new.config
   end
 end

--- a/lib/debugs_bunny/internal/templates/initializers/debugs_bunny.erb
+++ b/lib/debugs_bunny/internal/templates/initializers/debugs_bunny.erb
@@ -5,3 +5,4 @@ require 'debugs_bunny'
 DebugsBunny.configuration.encryption_cmk_key_id = DEBUGS_BUNNY_ALIAS # Change me to your CMK Key ID
 DebugsBunny.configuration.encryption_key_cache_timeout = 5.minutes
 DebugsBunny.configuration.encryption_partition_guid = 'DEBUGS_BUNNY_PARTITION'
+DebugsBunny.configuration.max_age = 1.week

--- a/lib/debugs_bunny/railtie.rb
+++ b/lib/debugs_bunny/railtie.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'debugs_bunny'
+require 'rails'
+
+module DebugsBunny
+  class Railtie < Rails::Railtie
+    railtie_name :debugs_bunny
+
+    rake_tasks do
+      path = File.expand_path(__dir__)
+      Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
+    end
+  end
+end

--- a/lib/debugs_bunny/railtie.rb
+++ b/lib/debugs_bunny/railtie.rb
@@ -8,8 +8,7 @@ module DebugsBunny
     railtie_name :debugs_bunny
 
     rake_tasks do
-      path = File.expand_path(__dir__)
-      Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
+      Dir.glob("#{TASKS_DIR}/**/*.rake").each { |f| load f }
     end
   end
 end

--- a/lib/debugs_bunny/tasks/trace.rake
+++ b/lib/debugs_bunny/tasks/trace.rake
@@ -4,6 +4,6 @@ namespace :debugs_bunny do
   desc 'Delete expired trace records'
   task delete_expired_traces: :environment do
     max_age = DebugsBunny.configuration.max_age
-    DebugsBunny::Trace.older_than(max_age).destroy_all
+    DebugsBunny::Trace.older_than(max_age).delete_all
   end
 end

--- a/lib/debugs_bunny/tasks/trace.rake
+++ b/lib/debugs_bunny/tasks/trace.rake
@@ -2,7 +2,7 @@
 
 namespace :debugs_bunny do
   desc 'Delete expired trace records'
-  task :delete_expired_traces do
+  task delete_expired_traces: :environment do
     max_age = DebugsBunny.configuration.max_age
     DebugsBunny::Trace.older_than(max_age).destroy_all
   end

--- a/lib/debugs_bunny/tasks/trace.rake
+++ b/lib/debugs_bunny/tasks/trace.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :debugs_bunny do
+  desc 'Delete expired trace records'
+  task :delete_expired_traces do
+    max_age = DebugsBunny.configuration.max_age
+    DebugsBunny::Trace.older_than(max_age).destroy_all
+  end
+end

--- a/lib/generators/debugs_bunny/install/install_generator.rb
+++ b/lib/generators/debugs_bunny/install/install_generator.rb
@@ -7,7 +7,7 @@ module DebugsBunny
     def install
       model_name = 'DebugTrace'
       generate "debugs_bunny:trace #{model_name}"
-      generate "debugs_bunny:migration:create_traces --table_name #{model_name}"
+      generate 'debugs_bunny:migration:create_traces'
       generate 'debugs_bunny:migration:create_encryption_keys'
       generate 'debugs_bunny:config'
     end

--- a/lib/generators/debugs_bunny/migration/create_traces/create_traces_generator.rb
+++ b/lib/generators/debugs_bunny/migration/create_traces/create_traces_generator.rb
@@ -8,15 +8,11 @@ module DebugsBunny
     class CreateTracesGenerator < Rails::Generators::Base
       include Rails::Generators::Migration
 
-      class_option :table_name, type: :string, required: true
-
       TEMPLATE_DIR = File.join(TEMPLATES_DIR, 'migrations')
       source_root TEMPLATE_DIR
 
       def generate_migration
-        table_name = options['table_name'].to_s.underscore.pluralize
         table = DebugsBunny::Trace.table_descriptor
-        table.name = table_name
 
         instance_eval do
           @table = table

--- a/lib/models/debugs_bunny/trace.rb
+++ b/lib/models/debugs_bunny/trace.rb
@@ -15,6 +15,20 @@ module DebugsBunny
 
     has_guid 'trc'
 
+    scope :created_before, ->(time) { where('created_at <= ?', time) }
+    scope :created_after, ->(time) { where('created_at >= ?', time) }
+    scope :created_between, ->(time_range) { where(created_at: time_range) }
+
+    scope :older_than, lambda { |age|
+      time = Time.now.utc - age
+      created_before(time)
+    }
+
+    scope :newer_than, lambda { |age|
+      time = Time.now.utc - age
+      created_after(time)
+    }
+
     def generate_partition_guid
       self.partition_guid = DebugsBunny.configuration.encryption_partition_guid
     end

--- a/lib/models/debugs_bunny/trace.rb
+++ b/lib/models/debugs_bunny/trace.rb
@@ -38,6 +38,7 @@ module DebugsBunny
     end
 
     define_table do |t|
+      t.name = 'debug_traces'
       t.define_column :guid, :string, null: false
       t.define_column :encrypted_dump, :string
       t.define_column :encrypted_dump_iv, :string
@@ -45,5 +46,7 @@ module DebugsBunny
       t.define_column :encryption_epoch, :string, null: false
       t.define_index :unique_guid, [:guid], unique: true
     end
+
+    self.table_name = @table_descriptor.name
   end
 end

--- a/spec/debugs_bunny/tasks/trace_task_spec.rb
+++ b/spec/debugs_bunny/tasks/trace_task_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'debugs_bunny:delete_expired_traces', type: :task do
   let(:file) { "#{DebugsBunny::ROOT_DIR}/lib/debugs_bunny/tasks/trace.rake" }
   let(:task) { subject }
@@ -29,3 +30,4 @@ RSpec.describe 'debugs_bunny:delete_expired_traces', type: :task do
     end
   end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/debugs_bunny/tasks/trace_task_spec.rb
+++ b/spec/debugs_bunny/tasks/trace_task_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+f = "#{DebugsBunny::ROOT_DIR}/lib/debugs_bunny/tasks/trace.rake"
+load f
+
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe 'debugs_bunny:delete_expired_traces', type: :task do
-  let(:file) { "#{DebugsBunny::ROOT_DIR}/lib/debugs_bunny/tasks/trace.rake" }
   let(:task) { subject }
 
   describe 'debugs_bunny:delete_expired_traces' do

--- a/spec/debugs_bunny/tasks/trace_task_spec.rb
+++ b/spec/debugs_bunny/tasks/trace_task_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe 'debugs_bunny:delete_expired_traces', type: :task do
+  let(:file) { "#{DebugsBunny::ROOT_DIR}/lib/debugs_bunny/tasks/trace.rake" }
+  let(:task) { subject }
+
+  describe 'debugs_bunny:delete_expired_traces' do
+    before do
+      create_list :debug_trace, 5
+      create_list :debug_trace, 5, created_at: 3.days.ago
+    end
+
+    after do
+      DebugsBunny.configuration.max_age = DebugsBunny.default_configuration.max_age
+    end
+
+    it 'deletes all expired traces' do
+      DebugsBunny.configuration.max_age = 1.day
+      expect do
+        run_task
+      end.to change(DebugTrace, :count).by(-5)
+    end
+
+    it 'does not delete traces that have not expired' do
+      DebugsBunny.configuration.max_age = 1.week
+      expect do
+        run_task
+      end.not_to change(DebugTrace, :count)
+    end
+  end
+end

--- a/spec/factories/debug_trace.rb
+++ b/spec/factories/debug_trace.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+class DebugTrace < DebugsBunny::Trace; end
+
 FactoryBot.define do
   factory :debug_trace, class: 'DebugTrace' do
     dump { 'Mr. Gorbachev, tear down this wall.' }

--- a/spec/generators/debugs_bunny/config_generator_spec.rb
+++ b/spec/generators/debugs_bunny/config_generator_spec.rb
@@ -1,20 +1,10 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 require 'generators/debugs_bunny/config/config_generator'
 
 RSpec.describe DebugsBunny::ConfigGenerator, type: :generator do
-  before do
-    clone_test_project
-    run_generator
-  end
-
-  after do
-    remove_test_project
-  end
-
   it 'creates an initializer file with the expected file name' do
+    run_generator
     path = initializer_file('debugs_bunny.rb')
     expect(File).to exist(path)
   end

--- a/spec/generators/debugs_bunny/install_generator_spec.rb
+++ b/spec/generators/debugs_bunny/install_generator_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 require 'generators/debugs_bunny/install/install_generator'
 
 RSpec.describe DebugsBunny::InstallGenerator, type: :generator do
@@ -10,31 +8,26 @@ RSpec.describe DebugsBunny::InstallGenerator, type: :generator do
   let(:debug_trace_migration_file_name) { "create_#{debug_trace_model_name.underscore.pluralize}.rb" }
   let(:encryption_key_migration_file_name) { 'create_encryption_keys.rb' }
 
-  before do
-    clone_test_project
-    run_generator
-  end
-
-  after do
-    remove_test_project
-  end
-
   it 'creates the DebugTrace model file' do
+    run_generator
     path = model_file(debug_trace_model_file_name)
     expect(File).to exist(path)
   end
 
   it 'creates the DebugTrace migration file' do
+    run_generator
     path = migration_file(debug_trace_migration_file_name)
     expect(File).to exist(path)
   end
 
   it 'creates the EncryptionKey migration file' do
+    run_generator
     path = migration_file(encryption_key_migration_file_name)
     expect(File).to exist(path)
   end
 
   it 'creates the configuration initializer file' do
+    run_generator
     path = initializer_file('debugs_bunny.rb')
     expect(File).to exist(path)
   end

--- a/spec/generators/debugs_bunny/migration/create_encryption_keys_generator_spec.rb
+++ b/spec/generators/debugs_bunny/migration/create_encryption_keys_generator_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 require 'generators/debugs_bunny/migration/create_encryption_keys/create_encryption_keys_generator'
 
 RSpec.describe DebugsBunny::Migration::CreateEncryptionKeysGenerator, type: :generator do
@@ -9,12 +7,7 @@ RSpec.describe DebugsBunny::Migration::CreateEncryptionKeysGenerator, type: :gen
   let(:file_name) { "create_#{table_name}.rb" }
 
   before do
-    clone_test_project
     allow(ActiveRecord::Base.connection).to receive(:table_exists?).and_return(false)
-  end
-
-  after do
-    remove_test_project
   end
 
   it 'creates a migration file' do

--- a/spec/generators/debugs_bunny/migration/create_traces_generator_spec.rb
+++ b/spec/generators/debugs_bunny/migration/create_traces_generator_spec.rb
@@ -1,28 +1,19 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 require 'generators/debugs_bunny/migration/create_traces/create_traces_generator'
 
 RSpec.describe DebugsBunny::Migration::CreateTracesGenerator, type: :generator do
   let(:table_name) { 'debug_traces' }
   let(:file_name) { "create_#{table_name}.rb" }
 
-  before do
-    clone_test_project
-    run_generator table_name: table_name
-  end
-
-  after do
-    remove_test_project
-  end
-
   it 'creates a migration file' do
+    run_generator
     path = migration_file(file_name)
     expect(File).to exist(path)
   end
 
   it 'creates a migration with the given table name' do
+    run_generator
     path = migration_file(file_name)
     read_file(path) do |contents|
       expect(contents).to include "create_table :#{table_name}"
@@ -30,6 +21,7 @@ RSpec.describe DebugsBunny::Migration::CreateTracesGenerator, type: :generator d
   end
 
   it 'creates a migration that inherits from the current ActiveRecord::Migration' do
+    run_generator
     path = migration_file(file_name)
     read_file(path) do |contents|
       expect(contents).to include "< ActiveRecord::Migration[#{ActiveRecord::Migration.current_version}]"
@@ -37,6 +29,7 @@ RSpec.describe DebugsBunny::Migration::CreateTracesGenerator, type: :generator d
   end
 
   it 'creates a migration with the expected guid column' do
+    run_generator
     path = migration_file(file_name)
     read_file(path) do |contents|
       expect(contents).to include 't.string :guid, null: false'
@@ -44,6 +37,7 @@ RSpec.describe DebugsBunny::Migration::CreateTracesGenerator, type: :generator d
   end
 
   it 'creates a migration with the expected encrypted dump columns' do
+    run_generator
     path = migration_file(file_name)
     read_file(path) do |contents|
       expect(contents).to include 't.string :encrypted_dump'
@@ -52,6 +46,7 @@ RSpec.describe DebugsBunny::Migration::CreateTracesGenerator, type: :generator d
   end
 
   it 'creates a migration with the expected timestamp columns' do
+    run_generator
     path = migration_file(file_name)
     read_file(path) do |contents|
       expect(contents).to include 't.timestamps'

--- a/spec/generators/debugs_bunny/trace_generator_spec.rb
+++ b/spec/generators/debugs_bunny/trace_generator_spec.rb
@@ -1,28 +1,19 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 require 'generators/debugs_bunny/trace/trace_generator'
 
 RSpec.describe DebugsBunny::TraceGenerator, type: :generator do
   let(:model_name) { 'DebugTrace' }
   let(:file_name) { 'debug_trace.rb' }
 
-  before do
-    clone_test_project
-    run_generator model_name
-  end
-
-  after do
-    remove_test_project
-  end
-
   it 'creates a model file with the given file name' do
+    run_generator model_name
     path = model_file(file_name)
     expect(File).to exist(path)
   end
 
   it 'creates a model with the given model name' do
+    run_generator model_name
     path = model_file(file_name)
     read_file(path) do |contents|
       expect(contents).to include "class #{model_name}"
@@ -30,6 +21,7 @@ RSpec.describe DebugsBunny::TraceGenerator, type: :generator do
   end
 
   it 'creates a model that inherits from Trace' do
+    run_generator model_name
     path = model_file(file_name)
     read_file(path) do |contents|
       expect(contents).to include "class #{model_name} < DebugsBunny::Trace"

--- a/spec/models/debugs_bunny/debug_trace_spec.rb
+++ b/spec/models/debugs_bunny/debug_trace_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe DebugTrace, type: :model do
 
   describe '::created_before' do
     let(:debug_trace_1) { create :debug_trace, created_at: Time.now.utc }
-    let(:debug_trace_2) { create :debug_trace, created_at: Time.now.utc - 3.days }
+    let(:debug_trace_2) { create :debug_trace, created_at: 3.days.ago }
 
     before do
       debug_trace_1
@@ -51,20 +51,20 @@ RSpec.describe DebugTrace, type: :model do
     end
 
     it 'returns all records created before the given time' do
-      traces = described_class.created_before(Time.now.utc - 1.day)
+      traces = described_class.created_before(1.day.ago)
       expect(traces.length).to eq 1
       expect(traces.first).to eq debug_trace_2
     end
 
     it 'returns no records if no records have been created before the given time' do
-      traces = described_class.created_before(Time.now.utc - 1.week)
+      traces = described_class.created_before(1.week.ago)
       expect(traces.length).to eq 0
     end
   end
 
   describe '::created_after' do
-    let(:debug_trace_1) { create :debug_trace, created_at: Time.now.utc - 1.day }
-    let(:debug_trace_2) { create :debug_trace, created_at: Time.now.utc - 3.days }
+    let(:debug_trace_1) { create :debug_trace, created_at: 1.day.ago }
+    let(:debug_trace_2) { create :debug_trace, created_at: 3.days.ago }
 
     before do
       debug_trace_1
@@ -72,7 +72,7 @@ RSpec.describe DebugTrace, type: :model do
     end
 
     it 'returns all records created after the given time' do
-      traces = described_class.created_after(Time.now.utc - 2.days)
+      traces = described_class.created_after(2.days.ago)
       expect(traces.length).to eq 1
       expect(traces.first).to eq debug_trace_1
     end
@@ -84,8 +84,8 @@ RSpec.describe DebugTrace, type: :model do
   end
 
   describe '::created_between' do
-    let(:debug_trace_1) { create :debug_trace, created_at: Time.now.utc - 1.day }
-    let(:debug_trace_2) { create :debug_trace, created_at: Time.now.utc - 3.days }
+    let(:debug_trace_1) { create :debug_trace, created_at: 1.day.ago }
+    let(:debug_trace_2) { create :debug_trace, created_at: 3.days.ago }
 
     before do
       debug_trace_1
@@ -93,21 +93,21 @@ RSpec.describe DebugTrace, type: :model do
     end
 
     it 'returns all records created between the given time range' do
-      traces = described_class.created_between(Time.now.utc - 1.week..Time.now.utc)
+      traces = described_class.created_between(1.week.ago..Time.now.utc)
       expect(traces.length).to eq 2
       expect(traces.first).to eq debug_trace_1
       expect(traces.second).to eq debug_trace_2
     end
 
     it 'returns no records if no records have been created between the given time range' do
-      traces = described_class.created_between(Time.now.utc - 2.months..Time.now.utc - 1.month)
+      traces = described_class.created_between(2.months.ago..1.month.ago)
       expect(traces.length).to eq 0
     end
   end
 
   describe '::older_than' do
-    let(:debug_trace_1) { create :debug_trace, created_at: Time.now.utc - 1.day }
-    let(:debug_trace_2) { create :debug_trace, created_at: Time.now.utc - 3.days }
+    let(:debug_trace_1) { create :debug_trace, created_at: 1.day.ago }
+    let(:debug_trace_2) { create :debug_trace, created_at: 3.days.ago }
 
     before do
       debug_trace_1
@@ -127,8 +127,8 @@ RSpec.describe DebugTrace, type: :model do
   end
 
   describe '::newer_than' do
-    let(:debug_trace_1) { create :debug_trace, created_at: Time.now.utc - 1.day }
-    let(:debug_trace_2) { create :debug_trace, created_at: Time.now.utc - 3.days }
+    let(:debug_trace_1) { create :debug_trace, created_at: 1.day.ago }
+    let(:debug_trace_2) { create :debug_trace, created_at: 3.days.ago }
 
     before do
       debug_trace_1

--- a/spec/models/debugs_bunny/debug_trace_spec.rb
+++ b/spec/models/debugs_bunny/debug_trace_spec.rb
@@ -44,4 +44,110 @@ RSpec.describe DebugTrace, type: :model do
       expect(found_record).to eq debug_trace
     end
   end
+
+  describe '::created_before' do
+    let(:debug_trace_1) { create :debug_trace, created_at: Time.now.utc }
+    let(:debug_trace_2) { create :debug_trace, created_at: Time.now.utc - 3.days }
+
+    before do
+      debug_trace_1
+      debug_trace_2
+    end
+
+    it 'returns all records created before the given time' do
+      traces = described_class.created_before(Time.now.utc - 1.day)
+      expect(traces.length).to eq 1
+      expect(traces.first).to eq debug_trace_2
+    end
+
+    it 'returns no records if no records have been created before the given time' do
+      traces = described_class.created_before(Time.now.utc - 1.week)
+      expect(traces.length).to eq 0
+    end
+  end
+
+  describe '::created_after' do
+    let(:debug_trace_1) { create :debug_trace, created_at: Time.now.utc - 1.day }
+    let(:debug_trace_2) { create :debug_trace, created_at: Time.now.utc - 3.days }
+
+    before do
+      debug_trace_1
+      debug_trace_2
+    end
+
+    it 'returns all records created after the given time' do
+      traces = described_class.created_after(Time.now.utc - 2.days)
+      expect(traces.length).to eq 1
+      expect(traces.first).to eq debug_trace_1
+    end
+
+    it 'returns no records if no records have been created after the given time' do
+      traces = described_class.created_after(Time.now.utc)
+      expect(traces.length).to eq 0
+    end
+  end
+
+  describe '::created_between' do
+    let(:debug_trace_1) { create :debug_trace, created_at: Time.now.utc - 1.day }
+    let(:debug_trace_2) { create :debug_trace, created_at: Time.now.utc - 3.days }
+
+    before do
+      debug_trace_1
+      debug_trace_2
+    end
+
+    it 'returns all records created between the given time range' do
+      traces = described_class.created_between(Time.now.utc - 1.week..Time.now.utc)
+      expect(traces.length).to eq 2
+      expect(traces.first).to eq debug_trace_1
+      expect(traces.second).to eq debug_trace_2
+    end
+
+    it 'returns no records if no records have been created between the given time range' do
+      traces = described_class.created_between(Time.now.utc - 2.months..Time.now.utc - 1.month)
+      expect(traces.length).to eq 0
+    end
+  end
+
+  describe '::older_than' do
+    let(:debug_trace_1) { create :debug_trace, created_at: Time.now.utc - 1.day }
+    let(:debug_trace_2) { create :debug_trace, created_at: Time.now.utc - 3.days }
+
+    before do
+      debug_trace_1
+      debug_trace_2
+    end
+
+    it 'returns all records older than the given age' do
+      traces = described_class.older_than(2.days)
+      expect(traces.length).to eq 1
+      expect(traces.first).to eq debug_trace_2
+    end
+
+    it 'returns no records if no records are older than the given age' do
+      traces = described_class.older_than(1.week)
+      expect(traces.length).to eq 0
+    end
+  end
+
+  describe '::newer_than' do
+    let(:debug_trace_1) { create :debug_trace, created_at: Time.now.utc - 1.day }
+    let(:debug_trace_2) { create :debug_trace, created_at: Time.now.utc - 3.days }
+
+    before do
+      debug_trace_1
+      debug_trace_2
+    end
+
+    it 'returns all records newer than the given age' do
+      traces = described_class.newer_than(2.days)
+      expect(traces.length).to eq 1
+      expect(traces.first).to eq debug_trace_1
+    end
+
+    it 'returns no records if no records are newer than the given age' do
+      traces = described_class.newer_than(1.minute)
+      expect(traces.length).to eq 0
+    end
+  end
 end

--- a/spec/models/debugs_bunny/debug_trace_spec.rb
+++ b/spec/models/debugs_bunny/debug_trace_spec.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
-class DebugTrace < DebugsBunny::Trace; end
-
 RSpec.describe DebugTrace, type: :model do
   it 'is valid with valid parameters' do
     debug_trace = build :debug_trace

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'database_cleaner'
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
+  config.before do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+
+    begin
+      DatabaseCleaner.start
+    ensure
+      DatabaseCleaner.clean
+    end
+  end
+end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -3,8 +3,6 @@
 require 'database_cleaner'
 
 RSpec.configure do |config|
-  config.include FactoryBot::Syntax::Methods
-
   config.before do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/support/debugs_bunny_spec_helper.rb
+++ b/spec/support/debugs_bunny_spec_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DebugsBunny
+  ROOT_DIR = File.expand_path('../..', __dir__)
+  SPEC_DIR = File.join(ROOT_DIR, 'spec')
+  TMP_DIR = File.join(ROOT_DIR, 'tmp')
+end
+
+RSpec.configure do |config|
+  config.include DebugsBunny
+end

--- a/spec/support/generator_spec_helper.rb
+++ b/spec/support/generator_spec_helper.rb
@@ -1,41 +1,16 @@
 # frozen_string_literal: true
 
 module Generators
-  ROOT_DIR = File.expand_path('../..', __dir__)
-  SPEC_DIR = File.join(ROOT_DIR, 'spec')
-  TMP_DIR = File.join(ROOT_DIR, 'tmp')
-
-  TEST_PROJECT_NAME = 'rails_test_app'
-
-  SRC_TEST_PROJECT_ROOT_DIR = File.join(SPEC_DIR, TEST_PROJECT_NAME).freeze
-
-  TMP_TEST_PROJECT_ROOT_DIR = File.join(TMP_DIR, TEST_PROJECT_NAME).freeze
-  TMP_TEST_PROJECT_APP_DIR = File.join(TMP_TEST_PROJECT_ROOT_DIR, 'app').freeze
-  TMP_TEST_PROJECT_MODEL_DIR = File.join(TMP_TEST_PROJECT_APP_DIR, 'models').freeze
-  TMP_TEST_PROJECT_MIGRATION_DIR = File.join(TMP_TEST_PROJECT_ROOT_DIR, File.join('db', 'migrate'))
-  TMP_TEST_PROJECT_CONFIG_DIR = File.join(TMP_TEST_PROJECT_ROOT_DIR, 'config').freeze
-  TMP_TEST_PROJECT_INITIALIZERS_DIR = File.join(TMP_TEST_PROJECT_CONFIG_DIR, 'initializers').freeze
-
   def generator_class
     described_class
   end
 
   def run_generator(*args, **kw_args)
     args = Array(args)
-    FileUtils.cd(TMP_TEST_PROJECT_ROOT_DIR) do
+    rails_context do
       g = generator_class.new(args, kw_args, {})
       g.invoke_all
     end
-  end
-
-  def remove_test_project
-    FileUtils.remove_dir TMP_TEST_PROJECT_ROOT_DIR if File.directory?(TMP_TEST_PROJECT_ROOT_DIR)
-  end
-
-  def clone_test_project
-    remove_test_project
-    FileUtils.mkdir_p(TMP_DIR) unless File.directory?(TMP_DIR)
-    FileUtils.cp_r SRC_TEST_PROJECT_ROOT_DIR, TMP_DIR
   end
 
   def read_file(path)
@@ -46,18 +21,18 @@ module Generators
   end
 
   def initializer_file(file_name)
-    File.join(TMP_TEST_PROJECT_INITIALIZERS_DIR, file_name)
+    File.join(RailsContext::TMP_TEST_PROJECT_INITIALIZERS_DIR, file_name)
   end
 
   def model_file(file_name)
-    File.join(TMP_TEST_PROJECT_MODEL_DIR, file_name)
+    File.join(RailsContext::TMP_TEST_PROJECT_MODEL_DIR, file_name)
   end
 
   def migration_file(file_name)
     basename = File.basename(file_name)
-    file_path = File.join(TMP_TEST_PROJECT_MIGRATION_DIR, "[0-9]*_#{basename}")
+    file_path = File.join(RailsContext::TMP_TEST_PROJECT_MIGRATION_DIR, "[0-9]*_#{basename}")
     file = Dir.glob(file_path).first
-    file = File.join(TMP_TEST_PROJECT_MIGRATION_DIR, "TIMESTAMP_#{basename}") if file.nil?
+    file = File.join(RailsContext::TMP_TEST_PROJECT_MIGRATION_DIR, "TIMESTAMP_#{basename}") if file.nil?
     file
   end
 end

--- a/spec/support/rails_spec_helper.rb
+++ b/spec/support/rails_spec_helper.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module RailsContext
+  TEST_PROJECT_NAME = 'rails_test_app'
+  SRC_TEST_PROJECT_ROOT_DIR = File.join(DebugsBunny::SPEC_DIR, TEST_PROJECT_NAME).freeze
+  TMP_TEST_PROJECT_ROOT_DIR = File.join(DebugsBunny::TMP_DIR, TEST_PROJECT_NAME).freeze
+
+  TMP_TEST_PROJECT_APP_DIR = File.join(TMP_TEST_PROJECT_ROOT_DIR, 'app').freeze
+  TMP_TEST_PROJECT_MODEL_DIR = File.join(TMP_TEST_PROJECT_APP_DIR, 'models').freeze
+  TMP_TEST_PROJECT_MIGRATION_DIR = File.join(TMP_TEST_PROJECT_ROOT_DIR, File.join('db', 'migrate'))
+  TMP_TEST_PROJECT_CONFIG_DIR = File.join(TMP_TEST_PROJECT_ROOT_DIR, 'config').freeze
+  TMP_TEST_PROJECT_INITIALIZERS_DIR = File.join(TMP_TEST_PROJECT_CONFIG_DIR, 'initializers').freeze
+
+  def self.included(klass)
+    klass.class_exec do
+      before do
+        clone_test_project
+      end
+
+      after do
+        remove_test_project
+      end
+    end
+  end
+
+  def rails_context
+    FileUtils.cd(TMP_TEST_PROJECT_ROOT_DIR) do
+      yield
+    end
+  end
+
+  def remove_test_project
+    FileUtils.remove_dir TMP_TEST_PROJECT_ROOT_DIR if File.directory?(TMP_TEST_PROJECT_ROOT_DIR)
+  end
+
+  def clone_test_project
+    remove_test_project
+    FileUtils.mkdir_p(DebugsBunny::TMP_DIR) unless File.directory?(DebugsBunny::TMP_DIR)
+    FileUtils.cp_r SRC_TEST_PROJECT_ROOT_DIR, DebugsBunny::TMP_DIR
+  end
+end
+
+RSpec.configure do |config|
+  config.include RailsContext
+end

--- a/spec/support/task_spec_helper.rb
+++ b/spec/support/task_spec_helper.rb
@@ -4,10 +4,7 @@ require 'rake'
 
 module Tasks
   def run_task
-    rails_context do
-      load file
-      Rake::Task[task].invoke
-    end
+    Rake::Task[task].execute
   end
 end
 

--- a/spec/support/task_spec_helper.rb
+++ b/spec/support/task_spec_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+module Tasks
+  def run_task
+    rails_context do
+      load file
+      Rake::Task[task].invoke
+    end
+  end
+end
+
+module Models
+  # Setup temporary database for testing
+  ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
+  load File.dirname(__FILE__) + '/test_schema.rb'
+end
+
+RSpec.configure do |config|
+  config.include Tasks, type: :task
+  config.include Models, type: :task
+end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/10189

*Why?*

Traces accumulate in the DB and take up significant memory. Traces have a limited useful lifespan, and can be deleted when expired. This reduces the memory held by traces.  

This also adds some more QOL functionality to the trace model:
- scope for `created_before`
- scope for `created_after`
- scope for `created_between`
- scope for `older_than` (used by the rake task)
- scope for `newer_than`

*How?*

- Add Rake task to delete traces older than lifetime X
- Add config var to specify the lifetime X

*Risks*

None

*Requested Reviewers*

@bcarr092 
@dragoszt 
@gregfletch 
