### PR TITLE
Fix: Persist traces after transaction rollback

### DIFF
--- a/lib/models/debugs_bunny/encryption_key.rb
+++ b/lib/models/debugs_bunny/encryption_key.rb
@@ -9,7 +9,7 @@ module DaffyLib
     after_rollback :rollback_callback
 
     def rollback_callback
-      self.class.create(attributes)
+      self.class.create(attributes.symbolize_keys)
     end
   end
 end

--- a/lib/models/debugs_bunny/encryption_key.rb
+++ b/lib/models/debugs_bunny/encryption_key.rb
@@ -4,6 +4,16 @@ require 'daffy_lib'
 
 require_relative 'concerns/can_generate'
 
+module DaffyLib
+  class EncryptionKey
+    after_rollback :rollback_callback
+
+    def rollback_callback
+      self.class.create(attributes)
+    end
+  end
+end
+
 module DebugsBunny
   class EncryptionKey < ::DaffyLib::EncryptionKey
     include CanGenerate

--- a/lib/models/debugs_bunny/trace.rb
+++ b/lib/models/debugs_bunny/trace.rb
@@ -29,6 +29,12 @@ module DebugsBunny
       created_after(time)
     }
 
+    after_rollback :rollback_callback
+
+    def rollback_callback
+      self.class.create({ **attributes, dump: dump })
+    end
+
     def generate_partition_guid
       self.partition_guid = DebugsBunny.configuration.encryption_partition_guid
     end

--- a/lib/models/debugs_bunny/trace.rb
+++ b/lib/models/debugs_bunny/trace.rb
@@ -32,7 +32,7 @@ module DebugsBunny
     after_rollback :rollback_callback
 
     def rollback_callback
-      self.class.create({ **attributes, dump: dump })
+      self.class.create({ **attributes.symbolize_keys, dump: dump })
     end
 
     def generate_partition_guid

--- a/spec/models/debugs_bunny/debug_trace_spec.rb
+++ b/spec/models/debugs_bunny/debug_trace_spec.rb
@@ -34,17 +34,19 @@ RSpec.describe DebugTrace, type: :model do
 
   # rubocop:disable RSpec/ExampleLength
   it 'persists if the enclosing transaction is rolled back' do
+    error_klass = Class.new(StandardError)
+
     guid = described_class.generate_guid
     dump = 'Hello world!'
 
     expect do
-      suppress(StandardError) do
+      suppress(error_klass) do
         described_class.transaction do
           described_class.transaction(requires_new: true) do
             create :debug_trace, dump: dump, guid: guid
-            raise StandardError
+            raise error_klass
           end
-          raise StandardError
+          raise error_klass
         end
       end
     end.to change(described_class, :count).by(1)

--- a/spec/models/debugs_bunny/debug_trace_spec.rb
+++ b/spec/models/debugs_bunny/debug_trace_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe DebugTrace, type: :model do
             create :debug_trace, dump: dump, guid: guid
             raise error_klass
           end
-          raise error_klass
         end
       end
     end.to change(described_class, :count).by(1)

--- a/spec/models/debugs_bunny/debug_trace_spec.rb
+++ b/spec/models/debugs_bunny/debug_trace_spec.rb
@@ -32,6 +32,29 @@ RSpec.describe DebugTrace, type: :model do
     expect(debug_trace.created_at).to be_present
   end
 
+  # rubocop:disable RSpec/ExampleLength
+  it 'persists if the enclosing transaction is rolled back' do
+    guid = described_class.generate_guid
+    dump = 'Hello world!'
+
+    expect do
+      suppress(StandardError) do
+        described_class.transaction do
+          described_class.transaction(requires_new: true) do
+            create :debug_trace, dump: dump, guid: guid
+            raise StandardError
+          end
+          raise StandardError
+        end
+      end
+    end.to change(described_class, :count).by(1)
+
+    traces = described_class.where(guid: guid)
+    expect(traces.length).to eq 1
+    expect(traces.first.dump).to eq dump
+  end
+  # rubocop:enable RSpec/ExampleLength
+
   describe '::find_by' do
     let(:debug_trace) { create :debug_trace }
 


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/10296

*Why?*

When creating a debug trace in a transaction, and an error is thrown, the transaction is closed and all database writes are rolled back. This erases the debug trace and nullifies our ability to perform debugging, effectively making the debug trace unusable for its intended purpose.

*How?*

At the point of rolling back a transaction that includes a debug trace, create a copy of the trace that is being rolled back to ensure a trace exists.

*Risks*

NA

*Requested Reviewers*

@bcarr092 
@dragoszt 
@gregfletch 
