### PR TITLE
Create dependabot yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    reviewers:
+    - michellefoy
+    assignees:
+    - michellefoy


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

[List the issues or tasks that are related to this pull request.
](https://github.com/Zetatango/zetatango/issues/21468)

*Why?*

This repo needs dependabot love. We keep getting NoMethodErrors in debugs bunny now and then:

```

2022-02-05T20:49:23.053721+00:00 host app web.1 - [0b20879e-6ea7-4fce-a238-0f5ebbac97c8] [3.238.44.104] [POST] [rest-client/2.1.0 (linux x86_64) ruby/3.0.2p107] [kyc.staging.thinkingcapital.ca] [/api/entities/merchants/m_vCjf7NffnqzRErLK/refresh] DebugsBunny failed to instantiate a new DebugTrace record due to an unknown error:
--



2022-02-05T20:49:23.054688+00:00 host app web.1 - [0b20879e-6ea7-4fce-a238-0f5ebbac97c8] [3.238.44.104] [POST] [rest-client/2.1.0 (linux x86_64) ruby/3.0.2p107] [kyc.staging.thinkingcapital.ca] [/api/entities/merchants/m_vCjf7NffnqzRErLK/refresh]   NoMethodError: undefined method `guid' for 1990:Integer
--




```

*How?*

Adding dependabot to see how we can update this repo so we don't get unexpected issues. I don't know if outdated dependency is the reason for the exception but worth adding regardless.

*Risks*

Low.

*Requested Reviewers*

@MattPreston-ZT @ahrke 